### PR TITLE
Display the next two upcoming rides.

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,7 +1,6 @@
 class PagesController < ApplicationController
   def index
     @this_week = Event.this_week
-    @next_week = Event.next_week
-    @events = [@this_week, @next_week].compact
+    @events = Event.next_two
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -2,6 +2,8 @@ class Event < ActiveRecord::Base
   belongs_to :ride
   belongs_to :route
 
+  scope :next_two, -> { where("begins_at < ?", Time.current.beginning_of_week).limit(2) }
+
   def self.this_week
     where(begins_at: Time.current.all_week).first
   end


### PR DESCRIPTION
We currently display this week + next week on the main index page.  If we've created a new set of events for the year, they won't be displayed until the starting week (e.g. 3/15). This changes to displaying the next two events regardless of when they occur.