### PR TITLE
Add Docker development build stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,33 @@ RUN bundle config set deployment true && \
     bundle config build.nokogiri --use-system-libraries && \
     bundle install
 
+# Development image
+FROM ruby:2.6-alpine as development
+
+RUN apk --no-cache add \
+    build-base \
+    libxml2-dev \
+    libxslt-dev \
+    nodejs \
+    postgresql-client \
+    postgresql-dev \
+    tzdata
+RUN gem install bundler:2.1.4
+
+ENV APP_HOME /app
+ENV BUNDLE_PATH /app/vendor/bundle
+RUN mkdir $APP_HOME
+WORKDIR $APP_HOME
+
+RUN adduser -D appuser
+USER appuser
+
+COPY --chown=appuser:appuser . $APP_HOME
+COPY --from=build --chown=appuser:appuser $APP_HOME/vendor/bundle $APP_HOME/vendor/bundle
+
+CMD ["bin/server"]
+
+# Production image
 FROM ruby:2.6-alpine
 
 RUN apk --no-cache add \

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,9 @@ RUN bundle config set deployment true && \
     bundle config build.nokogiri --use-system-libraries && \
     bundle install
 
-# Development image
+#####################
+# Development image #
+#####################
 FROM ruby:2.6-alpine as development
 
 RUN apk --no-cache add \
@@ -45,7 +47,9 @@ COPY --from=build --chown=appuser:appuser $APP_HOME/vendor/bundle $APP_HOME/vend
 
 CMD ["bin/server"]
 
-# Production image
+####################
+# Production image #
+####################
 FROM ruby:2.6-alpine
 
 RUN apk --no-cache add \

--- a/README.md
+++ b/README.md
@@ -63,9 +63,19 @@ $ docker-compose up
 $ docker-compose run --rm web bin/rails c
 ```
 
+#### Install gems
+
+```
+$ docker-compose run --rm web bundle install
+```
+
 #### Volumes
 
-The Dockerfile uses a multi-stage build process to reduce image size. After adding new gems to the image, they may not be available with when running with docker-compose. These would usually be installed with `bin/server`, but if they require native extensions then there's a good chance that you'll run into compilation issues. One workaround is to simply remove docker-compose volume with: `docker-compose down -v`
+Reset docker volumes (keep in mind this will remove all postgres data and bundled gems)
+
+```
+$ docker-compose down --volumes
+```
 
 #### Heroku
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,9 @@ version: '3.4'
 
 services:
   web:
-    build: .
+    build:
+      context: .
+      target: development
     ports:
       - "3000:3000"
     env_file: .env


### PR DESCRIPTION
Add a development build stage, so we can build gems (with native extensions) inside a container. Previously you had to `bundle install` outside of docker (to update `Gemfile.lock`) and then `bundle install` again inside the container.

**Overview**
* Add a new `development` build stage
* Configure that build stage with `target: development` in `docker-compose.yml`
* Update  instructions in`README.md`
