### PR TITLE
Restore litestream data when running rake tasks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,7 @@ USER appuser
 COPY --chown=appuser:appuser . $APP_HOME
 COPY --from=build --chown=appuser:appuser $APP_HOME/vendor/bundle $APP_HOME/vendor/bundle
 
+ENTRYPOINT ["./docker-entrypoint.sh"]
 CMD ["bin/server"]
 
 ####################
@@ -91,4 +92,5 @@ COPY --from=build --chown=appuser:appuser $APP_HOME/vendor/bundle $APP_HOME/vend
 
 RUN RAILS_ENV=production SECRET_KEY_BASE=$(bin/rake secret) bin/rake assets:clean assets:precompile
 
+ENTRYPOINT ["./docker-entrypoint.sh"]
 CMD ["bin/server"]

--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -20,7 +20,7 @@ class Admin::EventsController < Admin::AdminController
   def update
     @event = Event.find(params[:id])
 
-    if @event.update_attributes(event_params)
+    if @event.update(event_params)
       redirect_to admin_dashboard_path
     else
       render :edit

--- a/app/controllers/admin/notifiers_controller.rb
+++ b/app/controllers/admin/notifiers_controller.rb
@@ -23,7 +23,7 @@ class Admin::NotifiersController < Admin::AdminController
   def update
     @notifier = Notifier.find(params[:id])
 
-    if @notifier.update_attributes(notifier_params)
+    if @notifier.update(notifier_params)
       redirect_to admin_ride_url(@ride)
     else
       render :action => :edit

--- a/app/controllers/admin/rides_controller.rb
+++ b/app/controllers/admin/rides_controller.rb
@@ -24,7 +24,7 @@ class Admin::RidesController < Admin::AdminController
   def update
     @ride = Ride.find(params[:id])
 
-    if @ride.update_attributes(ride_params)
+    if @ride.update(ride_params)
       redirect_to admin_dashboard_path
     else
       render :edit

--- a/app/controllers/admin/routes_controller.rb
+++ b/app/controllers/admin/routes_controller.rb
@@ -18,7 +18,7 @@ class Admin::RoutesController < Admin::AdminController
   def update
     @route = Route.find(params[:id])
 
-    if @route.update_attributes(route_params)
+    if @route.update(route_params)
       redirect_to admin_dashboard_path
     else
       render :action => :edit

--- a/bin/server
+++ b/bin/server
@@ -6,7 +6,6 @@ rm -f ./tmp/pids/server.pid
 echo "Installing gems."
 bundle check || (bundle install && bundle clean)
 
-
 run_server() {
   echo "Starting Rails Server."
   bundle exec rails server -b 0.0.0.0 -p $PORT
@@ -17,27 +16,8 @@ run_server_with_replication() {
   litestream replicate -exec "bundle exec rails server -b 0.0.0.0 -p $PORT" $LITESTREAM_DATA_PATH $LITESTREAM_REPLICA_URL
 }
 
-restore_data() {
-  if [ ! -f $LITESTREAM_DATA_PATH ]; then
-    echo "Restoring litestream data."
-    litestream restore -v -if-replica-exists -o $LITESTREAM_DATA_PATH $LITESTREAM_REPLICA_URL
-  fi
-
-  # Create symlink to the data path
-  ln -nfs $LITESTREAM_DATA_PATH $APP_DATA_PATH
-}
-
-if [ $STORAGE_MODE == "local" ]; then
-  # Remove symlink if it exists
-  [ -L "$APP_DATA_PATH" ] && rm -f $APP_DATA_PATH
-
-  run_server
+if [ $STORAGE_MODE == "replication" ]; then
+  run_server_with_replication
 else
-  if [ $STORAGE_MODE == "restore_only" ]; then
-    restore_data
-    run_server
-  elif [ $STORAGE_MODE == "replication" ]; then
-    restore_data
-    run_server_with_replication
-  fi
+  run_server
 fi

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,18 +2,15 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# Note that this schema.rb definition is the authoritative source for your
-# database schema. If you need to create the application database on another
-# system, you should be using db:schema:load, not running all the migrations
-# from scratch. The latter is a flawed and unsustainable approach (the more migrations
-# you'll amass, the slower it'll run and the greater likelihood for issues).
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2017_02_28_033544) do
-
-  # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
 
   create_table "events", force: :cascade do |t|
     t.datetime "begins_at"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -12,7 +12,9 @@ restore_data() {
 }
 
 remove_symlink() {
-  [ -L "$APP_DATA_PATH" ] && rm -f $APP_DATA_PATH
+  if [ -L "$APP_DATA_PATH" ]; then
+    rm -f $APP_DATA_PATH
+  fi
 }
 
 if [ $STORAGE_MODE == "local" ]; then

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+set -e
+
+restore_data() {
+  if [ ! -f $LITESTREAM_DATA_PATH ]; then
+    echo "Restoring litestream data."
+    litestream restore -v -if-replica-exists -o $LITESTREAM_DATA_PATH $LITESTREAM_REPLICA_URL
+  fi
+
+  # Create symlink to the data path
+  ln -nfs $LITESTREAM_DATA_PATH $APP_DATA_PATH
+}
+
+remove_symlink() {
+  [ -L "$APP_DATA_PATH" ] && rm -f $APP_DATA_PATH
+}
+
+if [ $STORAGE_MODE == "local" ]; then
+  remove_symlink
+else
+  restore_data
+fi
+
+exec "$@"

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -1,6 +1,5 @@
 desc "Send weekly notifications"
 task :send_notifications => :environment do
-  # `source bin/restore_data && restore_data`
   puts "Event this week: #{Event.this_week.present?}"
 
   if(Time.now.wday == 3)  # Send the weekly email/tweet on Wednesday.

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -1,4 +1,8 @@
+desc "Send weekly notifications"
 task :send_notifications => :environment do
+  # `source bin/restore_data && restore_data`
+  puts "Event this week: #{Event.this_week.present?}"
+
   if(Time.now.wday == 3)  # Send the weekly email/tweet on Wednesday.
     WeeklyEventNotifier.send_weekly_event_notification
   end


### PR DESCRIPTION
We need to restore the litestream DB before running rake task (that depend on that data)

* Add docker-entrypoint.sh and move `restore_data` function there
* Clean-up `bin/server`