### PR TITLE
Install Heroku CLI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
 
+      - name: Install Heroku CLI
+        run: curl https://cli-assets.heroku.com/install.sh | sh
+
       - name: Login to Heroku container registry
         run: heroku container:login
 
@@ -67,6 +70,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v1
+
+      - name: Install Heroku CLI
+        run: curl https://cli-assets.heroku.com/install.sh | sh
 
       - name: Login to Heroku container registry
         run: heroku container:login


### PR DESCRIPTION
Install Heroku CLI before building staging/production images.

Ubuntu 24.04 no long includes the Heroku CLI:
https://github.com/actions/runner-images/issues/10636