### PR TITLE
Global messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ https://devcenter.heroku.com/articles/container-registry-and-runtime
 
 (The MIT License)
 
-Copyright © 2010-2023 Andrew Olson.
+Copyright © 2010-2025 Andrew Olson.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the ‘Software’), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -128,6 +128,14 @@ ul.block li span, ul.block li a {
   color: #999;
 }
 
+#global-message {
+  border-top: 5px solid #DDD;
+  background: #333;
+  color: #EFEFEF;
+  text-align: center;
+  padding: 5px;
+}
+
 .box {
   background: #333;
   color:#eee;

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,5 +1,6 @@
 class PagesController < ApplicationController
   def index
+    @global_message = ENV["GLOBAL_MESSAGE"]
     @this_week = Event.this_week
     @events = Event.upcoming
   end

--- a/app/views/pages/_global_message.html.erb
+++ b/app/views/pages/_global_message.html.erb
@@ -1,0 +1,6 @@
+<% if @global_message.present? %>
+  <section id="global-message">
+    <p><%= @global_message %></p>
+    <div class="clear"></div>
+  </section>
+<% end %>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -1,3 +1,4 @@
+<%= render partial: 'global_message' %>
 <%= render partial: 'this_week' %>
 <%= render partial: 'about', locals: { events: @events } %>
 <%= render partial: 'rides', locals: { events: @events } %>

--- a/spec/features/pages_spec.rb
+++ b/spec/features/pages_spec.rb
@@ -15,11 +15,41 @@ RSpec.feature "Pages" do
       let!(:this_week) { create :event, :this_week }
       let(:route) { this_week.route }
 
-      scenario "displays an appropriate message" do
+      scenario "displays info about the current ride" do
         visit "/"
 
         expect(page).to have_text("Wednesday Worlds")
         expect(page).to have_text("The ride this week is #{route.name}")
+      end
+    end
+
+
+    describe "Global messaging" do
+      let(:message) { "Test message" }
+
+      describe "With global messaging configured" do
+        before { stub_global_message }
+
+        scenario "displays the message" do
+          visit "/"
+
+          expect(page).to have_text("Wednesday Worlds")
+          expect(page).to have_text(message)
+        end
+      end
+
+      describe "Without global messaging configured" do
+        scenario "doesn't display the message" do
+          visit "/"
+
+          expect(page).to have_text("Wednesday Worlds")
+          expect(page).not_to have_text(message)
+        end
+      end
+
+      def stub_global_message
+        allow(ENV).to receive(:[]).and_call_original
+        allow(ENV).to receive(:[]).with("GLOBAL_MESSAGE").and_return(message)
       end
     end
   end


### PR DESCRIPTION
Metallica is in town the week of 5/7 and we'd like to display a message that there won't be a ride that week.

This adds support for displaying a message at the top of the index page. 

* Only one message can be configured at a time
* The message can be configured by set the `GLOBAL_MESSAGE` environment variable