### PR TITLE
Dual-license repo: MIT for code, CC BY 4.0 for content

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,9 @@
+The MIT License
+
+Copyright © 2010-2026 Wednesday Worlds.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the ‘Software’), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED ‘AS IS’, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -109,12 +109,6 @@ https://devcenter.heroku.com/articles/container-registry-and-runtime
 
 ### License
 
-(The MIT License)
+Code is licensed under the [MIT License](LICENSE); site content (copy, ride/route descriptions) is licensed under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/).
 
-Copyright © 2010-2025 Andrew Olson.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the ‘Software’), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED ‘AS IS’, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+Copyright © 2010-2026 Wednesday Worlds.

--- a/app/views/common/_copyright.html.erb
+++ b/app/views/common/_copyright.html.erb
@@ -1,1 +1,1 @@
-&copy; 2010 – <%= Date.current.year %> Andrew Olson
+&copy; 2010 – <%= Date.current.year %> Wednesday Worlds. Content licensed under <a rel="license" href="https://creativecommons.org/licenses/by/4.0/">CC BY 4.0</a>.


### PR DESCRIPTION
## Summary
- Adds a root `LICENSE` file (MIT) for the codebase
- Licenses site content (copy, ride/route descriptions) under CC BY 4.0
- Attributes copyright to "Wednesday Worlds" instead of an individual name, in both the footer partial and README

## Test plan
- [x] Verified `_copyright.html.erb` renders on both the public (`application.html.erb`) and admin (`admin.html.erb` via `common/footer`) layouts
- [x] Confirmed no other files reference the old personal-name copyright notice